### PR TITLE
Proposal for inclusion in Twitter list

### DIFF
--- a/index.md
+++ b/index.md
@@ -157,6 +157,7 @@ layout: home
 * [GuyNAustin](https://twitter.com/GuyNAustin) (@GuyNAustin)
 * [Carnivore Aurelius](https://twitter.com/KetoAurelius) (@KetoAurelius)
 * [nutritionwithjudy](https://twitter.com/nutritionwjudy) (@NutritionwJudy)
+* [Dr. Tro](https://twitter.com/DoctorTro) (@DoctorTro)
 * [Carnivores Twitter List](https://twitter.com/sarahkaltsounis/lists/carnivores)
 
 ## Instagram


### PR DESCRIPTION
I propose the inclusion of Dr. Tro Kalayjian to the Twitter section of the justmeat.co list.

Dr. Tro Kalayjian is a board-certified physician in Internal Medicine and Obesity Medicine. He lost 150lbs to reclaim his health and is an avid proponent of low carb, high protein dieting. He maintains a large list of free resources (go to his website, [DoctorTro.com](https://www.doctortro.com/) and check the 'Free Resources' section) and runs a weekly podcast called '[The Low Carb MD Podcast](http://lowcarbmd.com/)'.  He is also very active on Twitter [@Tro](https://twitter.com/DoctorTro).